### PR TITLE
Change buttons and selections

### DIFF
--- a/driftermap.html
+++ b/driftermap.html
@@ -52,6 +52,9 @@
               .ol-popup-closer:after {
                 content: "✖";
               }
+            button {
+                width: 60px; height: 60px;
+            }
         </style>
     </head>
 


### PR DESCRIPTION
Set button sizes to a fixed 60x60px.

Change selection behaviour to:
- select and highlight single drifter on singleclick
- add to or remove from selection on shiftclick
- empty selection on singleclick where there is no feature
- add export button, which redirects to the url with the query reproducing the current selection

Resolves #2, resolves #4, resolves #9